### PR TITLE
Create a document holding devlang of cpp only

### DIFF
--- a/openpublishing/test/f1query/cplusplusOnly
+++ b/openpublishing/test/f1query/cplusplusOnly
@@ -1,0 +1,30 @@
+---
+f1_keywords:
+- samplef1keyword3
+dev_langs:
+- cpp
+target_framework_moniker:
+- Office.Version=v15
+---
+
+# How To Publish Content to Enable F1 Query
+
+## Metadata Strategy
+1. **f1_keywords** (_optional_, _multivalue_): **This metadata is mandatory for F1 Query.** Need to provide one or more F1 keywords for this content, which will be used to match the keywords from F1 query URL.
+
+2. **dev_langs** (_optional_, _multivalue_): **This metadata is optional for F1 Query.** The supported develop languages of this content. The F1 query will specify the dev_lang that the develop is currently using in the IDE. 
+
+
+##YAML Header
+The metadata is set in YAML header of the Markdown file of your content:
+
+```md
+f1_keywords:
+- samplef1keyword3
+dev_langs:
+- cpp
+target_framework_moniker:
+- Office.Version=v15
+version: 15
+locale: en-us
+```


### PR DESCRIPTION
There are some issues in our content f1 metadata that (c++/cpp) both exist in different topics as devlang. This document is created for testing (integration test) f1 api compatibility of those two spellings.